### PR TITLE
Enable multiple aliases

### DIFF
--- a/NgEmojiMap/NgEmojiMap.m
+++ b/NgEmojiMap/NgEmojiMap.m
@@ -46,11 +46,18 @@
   [emojis enumerateObjectsUsingBlock:^(NSDictionary * dict, NSUInteger idx, BOOL *stop) {
     NSString * unicode = dict[@"emoji"];
     if (!unicode) return;
-    NSString * alias = [dict[@"aliases"] firstObject];
-    if (!alias) return;
-    
-    unicodeToAliasMapping[unicode] = alias;
-    aliasToUnicodeMapping[alias] = unicode;
+    [emojis enumerateObjectsUsingBlock:^(NSDictionary * dict, NSUInteger idx, BOOL *stop) {
+      NSString * unicode = dict[@"emoji"];
+      if (!unicode) return;
+      NSArray *aliases = dict[@"aliases"];
+      if (aliases.count == 0) return;
+      for (NSString *alias in aliases) {
+        if (!unicodeToAliasMapping[unicode]) {
+            unicodeToAliasMapping[unicode] = alias;
+        }
+        aliasToUnicodeMapping[alias] = unicode;
+      }
+    }];
   }];
   
   _unicodeToAliasMapping = [unicodeToAliasMapping copy];

--- a/NgEmojiMapTests/NgEmojiMapTests.m
+++ b/NgEmojiMapTests/NgEmojiMapTests.m
@@ -30,6 +30,7 @@
 {
   XCTAssertEqualObjects(@"😃", [[NgEmojiMap sharedInstance] emojiForAlias:@"smiley"]);
   XCTAssertEqualObjects(@"smiley", [[NgEmojiMap sharedInstance] aliasForEmoji:@"😃"]);
+  XCTAssertNotNil([[NgEmojiMap sharedInstance] emojiForAlias:@"thumbsup"]);
   BOOL isMember = [(@"😃") rangeOfCharacterFromSet:[[NgEmojiMap sharedInstance] characterSet]].location != NSNotFound;
   XCTAssert(isMember);
   isMember = [(@"a") rangeOfCharacterFromSet:[[NgEmojiMap sharedInstance] characterSet]].location != NSNotFound;


### PR DESCRIPTION
This enables the thumbsup to be referenced by either of its aliases.

```
{
    "emoji": "👍"
  , "description": "thumbs up sign"
  , "aliases": [
      "+1"
    , "thumbsup"
    ]
  , "tags": [
      "approve"
    , "ok"
    ]
  }
```
